### PR TITLE
expand file path

### DIFF
--- a/R/udpipe_parse.R
+++ b/R/udpipe_parse.R
@@ -28,6 +28,7 @@
 #' ud_dutch <- udpipe_load_model(f)
 #' }
 udpipe_load_model <- function(file) {
+  file = path.expand(file)
   if(!file.exists(file)){
     stop(sprintf("File %s containing the language model does not exist", file))
   }


### PR DESCRIPTION
At the moment `udpipe_load_model` can't correctly load models from paths like "~/path/to/model". Wrapping path with `path.expand()` fixes problem.